### PR TITLE
add error annotation to license errors

### DIFF
--- a/ghascompliance/checks.py
+++ b/ghascompliance/checks.py
@@ -204,7 +204,7 @@ class Checks:
         )
 
         licensing_errors = 0
-        #
+
         dependabot = Dependencies(self.github)
 
         alerts = self.getResults("dependencies", dependabot.getDependencies)

--- a/ghascompliance/checks.py
+++ b/ghascompliance/checks.py
@@ -204,7 +204,7 @@ class Checks:
         )
 
         licensing_errors = 0
-
+        #
         dependabot = Dependencies(self.github)
 
         alerts = self.getResults("dependencies", dependabot.getDependencies)

--- a/ghascompliance/policy.py
+++ b/ghascompliance/policy.py
@@ -405,12 +405,13 @@ class Policy:
         )
         dependency_full = dependency.get("full_name", "NA://NA#NA")
 
+        # gather warning ids and names
         warning_ids = [wrn.lower() for wrn in policy.get("warnings", {}).get("ids", [])]
         warning_names = [
             wrn.lower() for wrn in policy.get("warnings", {}).get("names", [])
         ]
 
-        #  If the license name is in the warnings list
+        #  if the license name is in the warnings list generate a warning
         if self.matchContent(license, warning_ids) or self.matchContent(
             dependency_full, warning_names
         ):
@@ -418,11 +419,13 @@ class Policy:
                 f"Dependency License Warning :: {dependency_full} = {license}"
             )
 
+        # gather ignore ids and names
         ingore_ids = [ign.lower() for ign in policy.get("ingores", {}).get("ids", [])]
         ingore_names = [
             ign.lower() for ign in policy.get("ingores", {}).get("names", [])
         ]
 
+        # gather condition ids and names
         condition_ids = [
             ign.lower() for ign in policy.get("conditions", {}).get("ids", [])
         ]
@@ -432,14 +435,18 @@ class Policy:
 
         for value in [license, dependency_full, dependency_name, dependency_short_name]:
 
+            # return false (ignore) if name or id is defined in the ignore portion of the policy
             if self.matchContent(value, ingore_ids) or self.matchContent(
                 value, ingore_names
             ):
                 return False
-
+            # annotate error and return true if name or id is defined as a condition
             elif self.matchContent(value, condition_ids) or self.matchContent(
                 value, conditions_names
             ):
+                Octokit.error(
+                    f"Dependency License Violation :: {dependency_full} == {license}"
+                )
                 return True
 
         return False


### PR DESCRIPTION
### TL;DR

This PR adds annotations when a license error (matching the `conditions` defined in the policy) is found.

### Details

License warnings (matching the `warnings` defined in the policy) currently generate annotations which display in the logs:

![image](https://user-images.githubusercontent.com/4007128/130001688-d9d313cd-b2d0-4623-b572-f7fc0f5841ce.png)

as well as in the workflow run page:

![image](https://user-images.githubusercontent.com/4007128/130001998-0241b212-33e3-4f1a-b9d4-2a399d20a787.png)

This PR adds the same notifications for policy violations, which previously generated no error message, making it harder for users to determine which package's license(s) are problematic.

![image](https://user-images.githubusercontent.com/4007128/130002184-8bbf55db-af6d-46f8-afcc-b0d11838b3d2.png)

![image](https://user-images.githubusercontent.com/4007128/130002255-1bd5c0c4-7b61-4c0d-a92f-2fe133c354b1.png)
