### PR TITLE
Update severities to include `note`

### DIFF
--- a/ghascompliance/consts.py
+++ b/ghascompliance/consts.py
@@ -10,6 +10,7 @@ SEVERITIES = [
     "warning",
     "warnings",
     # Informational issues
+    "note",
     "notes",
 ]
 


### PR DESCRIPTION
Add the `note` level to the severities list.

Resolves #39 