### PR TITLE
Add GitHub App API token authentication to clone custom policy inside a private repository

### DIFF
--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -85,7 +85,6 @@ if __name__ == "__main__":
         instance=arguments.github_instance,
         token=arguments.github_token,
     )
-    print(github)
 
     Octokit.info(f"GitHub Repository :: {github.repo}")
     Octokit.info(f"GitHub Instance :: {github.instance}")

--- a/ghascompliance/__main__.py
+++ b/ghascompliance/__main__.py
@@ -30,7 +30,8 @@ parser.add_argument("--disable-code-scanning", action="store_true")
 parser.add_argument("--disable-dependabot", action="store_true")
 parser.add_argument("--disable-dependency-licensing", action="store_true")
 parser.add_argument("--disable-dependencies", action="store_true")
-parser.add_argument("--disable-secret-scanning", action="store_true")
+parser.add_argument("--disable-secret-scanning", action="store_true")   
+parser.add_argument("--is-github-app-token", action="store_true", default=False)
 
 github_arguments = parser.add_argument_group("GitHub")
 github_arguments.add_argument("--github-token", default=GITHUB_TOKEN)
@@ -84,6 +85,7 @@ if __name__ == "__main__":
         instance=arguments.github_instance,
         token=arguments.github_token,
     )
+    print(github)
 
     Octokit.info(f"GitHub Repository :: {github.repo}")
     Octokit.info(f"GitHub Instance :: {github.instance}")
@@ -128,7 +130,9 @@ if __name__ == "__main__":
         severity=arguments.severity,
         repository=policy_location,
         path=arguments.github_policy_path,
+        branch=arguments.github_policy_branch,
         token=arguments.github_token,
+        isGithubAppToken=arguments.is_github_app_token,
         instance=arguments.github_instance,
     )
 

--- a/ghascompliance/policy.py
+++ b/ghascompliance/policy.py
@@ -26,6 +26,7 @@ class Policy:
         severity="error",
         repository=None,
         token=None,
+        isGithubAppToken=False,
         path=None,
         branch=None,
         instance="https://github.com",
@@ -39,11 +40,13 @@ class Policy:
 
         self.instance = instance
         self.token = token
+        self.isGithubAppToken = isGithubAppToken
         self.branch = branch
         self.repository = repository
         self.repository_path = path
 
         self.temp_repo = None
+
 
         if repository and repository != "":
             self.loadFromRepo()
@@ -53,7 +56,10 @@ class Policy:
     def loadFromRepo(self):
         instance = urlparse(self.instance).netloc
         if self.token:
-            repo = "https://" + self.token + "@" + instance + "/" + self.repository
+            if not self.isGithubAppToken:
+                repo = "https://" + self.token + "@" + instance + "/" + self.repository
+            else:
+                repo = "https://" + "x-access-token:" + self.token + "@" + instance + "/" + self.repository
         else:
             repo = "https://" + instance + "/" + self.repository
 
@@ -85,6 +91,7 @@ class Policy:
             raise Exception("Repository failed to clone")
 
         full_path = os.path.join(self.temp_repo, self.repository_path)
+        print(full_path)
 
         self.loadLocalConfig(full_path)
 

--- a/ghascompliance/policy.py
+++ b/ghascompliance/policy.py
@@ -91,7 +91,6 @@ class Policy:
             raise Exception("Repository failed to clone")
 
         full_path = os.path.join(self.temp_repo, self.repository_path)
-        print(full_path)
 
         self.loadLocalConfig(full_path)
 


### PR DESCRIPTION
As stated in issue #50, the custom policy clone using GitHub App API token is not possible as ```x-access-token```username need to be set in the ```https``` clone link. 

I've added an optionnal argument ```--is-github-app-token``` to specify if the authentication token is a GitHub App API token, and set the ```x-access-token``` username needed to clone the policy.

I've also added the ```branch``` argument to ```Policy()```call, as it was actually never used.