### PR TITLE
Do not alert on `fixed` dependabot alerts

### DIFF
--- a/ghascompliance/octokit/dependabot.py
+++ b/ghascompliance/octokit/dependabot.py
@@ -6,7 +6,7 @@ from ghascompliance.octokit.octokit import GitHub, OctoRequests, Octokit
 GRAPHQL_GET_INFO = """\
 {
     repository(owner: "$owner", name: "$repo") {
-        vulnerabilityAlerts(first: 100) {
+        vulnerabilityAlerts(first: 100, states: [OPEN]) {
             nodes {
                 createdAt
                 dismissReason


### PR DESCRIPTION
Currently Dependabot alerts are only filtered where `dismissReason` is set. However that value is only set when the user has manually dismissed the alert.

The expected outcome of a Dependabot alert would be for the dependency to be updated, at which point Dependabot automatically marks the alert as Fixed. In this situation advanced-security-compliance continues to fail, because those alerts are still considered in-scope.

This PR resolves that behaviour by filtering for OPEN Dependabot alerts only, thus ignoring DISMISSED and FIXED.

See: https://docs.github.com/en/graphql/reference/enums#repositoryvulnerabilityalertstate