### PR TITLE
Remove empty `tests` script which trips up Pipenv >=2022.9.20

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,5 +17,4 @@ python_version = "3.9"
 
 [scripts]
 main = "python -m ghascompliance"
-tests = ""
 format = "black ."

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here is how you can quickly setup advanced-security-compliance.
 ```yaml
 # Compliance
 - name: Advance Security Compliance Action
-  uses: GeekMasher/advanced-security-compliance@v1.6.1
+  uses: GeekMasher/advanced-security-compliance@v1.6.2
 ```
 
 #### Action Examples
@@ -59,7 +59,7 @@ Here is an example of using a simple yet cross-organization using Policy as Code
 ```yaml
 # Compliance
 - name: Advance Security Compliance Action
-  uses: GeekMasher/advanced-security-compliance@v1.6.1
+  uses: GeekMasher/advanced-security-compliance@v1.6.2
   with:
     # The owner/repo of where the policy is stored  
     policy: GeekMasher/security-queries

--- a/ghascompliance/__version__.py
+++ b/ghascompliance/__version__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 
 __title__ = "GitHub Advanced Security Compliance"
 __name__ = "ghascompliance"


### PR DESCRIPTION
Pipenv 2022.9.20 was just realeased, and they updated dependencies for Pipfile parsing to `plette`.
This results in a Schema validation error for the existing Pipfile, due to an empty value for the script `tests`.

```
pipenv.vendor.plette.models.base.ValidationError: {'__script__': ''}
__script__: empty values not allowed
```

This PR fixes that by removing the unusued `tests` script declaration from Pipenv.
After this change, Pipenv 2022.9.20 runs successfully.

It also bumps the version to 1.6.2.